### PR TITLE
Disable aria-autocomplete in ComboboxInput

### DIFF
--- a/lib/ComboboxInput.js
+++ b/lib/ComboboxInput.js
@@ -50,6 +50,7 @@ exports['default'] = _react2['default'].createClass({
       type: 'text',
       'aria-disabled': this.props.disabled,
       'aria-readonly': this.props.readOnly,
+      'aria-autocomplete': 'none',
       className: this.props.className + ' rw-input',
       onKeyDown: this.props.onKeyDown,
       onChange: this._change,

--- a/lib/DateTimePicker.js
+++ b/lib/DateTimePicker.js
@@ -149,7 +149,7 @@ var DateTimePicker = _react2['default'].createClass(babelHelpers.createDecorated
       var calIsActive = open === popups.CALENDAR && key === 'calendar';
       var timeIsActive = open === popups.TIME && key === 'timelist';
 
-      if (!current || (timeIsActive || calIsActive)) return id;
+      if (!current || timeIsActive || calIsActive) return id;
     })];
   }
 }, {

--- a/lib/Popup.js
+++ b/lib/Popup.js
@@ -16,9 +16,9 @@ function properties(prop, value) {
 
   var TRANSLATION_MAP = config.animate.TRANSLATION_MAP;
 
-  if (TRANSLATION_MAP && TRANSLATION_MAP[prop]) return (_ref = {}, _ref[transform] = TRANSLATION_MAP[prop] + '(' + value + ')', _ref);
+  if (TRANSLATION_MAP && TRANSLATION_MAP[prop]) return _ref = {}, _ref[transform] = TRANSLATION_MAP[prop] + '(' + value + ')', _ref;
 
-  return (_ref2 = {}, _ref2[prop] = value, _ref2);
+  return _ref2 = {}, _ref2[prop] = value, _ref2;
 }
 
 var PopupContent = React.createClass({

--- a/lib/mixins/DataFilterMixin.js
+++ b/lib/mixins/DataFilterMixin.js
@@ -44,7 +44,7 @@ module.exports = {
     if (!searchTerm || !searchTerm.trim() || this.props.filter && searchTerm.length < (this.props.minLength || 1)) return -1;
 
     items.every(function (item, i) {
-      if (matches(item, searchTerm, i)) return (idx = i, false);
+      if (matches(item, searchTerm, i)) return idx = i, false;
 
       return true;
     });

--- a/lib/util/_.js
+++ b/lib/util/_.js
@@ -53,7 +53,7 @@ var _ = module.exports = {
     var result;
     if (Array.isArray(arr)) {
       arr.every(function (val, idx) {
-        if (cb.call(thisArg, val, idx, arr)) return (result = val, false);
+        if (cb.call(thisArg, val, idx, arr)) return result = val, false;
         return true;
       });
       return result;

--- a/src/ComboboxInput.jsx
+++ b/src/ComboboxInput.jsx
@@ -38,6 +38,7 @@ export default React.createClass({
         type='text'
         aria-disabled={this.props.disabled}
         aria-readonly={this.props.readOnly}
+        aria-autocomplete='none'
         className={this.props.className + ' rw-input'}
         onKeyDown={this.props.onKeyDown}
         onChange={this._change}


### PR DESCRIPTION
The aria-autcomplete which is present in browsers appears above the dropdown from react-widgets. This allows a user to select the native browser dropdown instead of the one from react-widgets, autofilling the wrong input.

@procore/financials @mboperator
