### PR TITLE
fix propTypes for combox

### DIFF
--- a/src/Combobox.jsx
+++ b/src/Combobox.jsx
@@ -29,7 +29,7 @@ let propTypes = {
 
       itemComponent:  CustomPropTypes.elementType,
       listComponent:  CustomPropTypes.elementType,
-      afterListComponent: CustomPropTypes.elementType,
+      afterListComponent: React.PropTypes.any,
       groupComponent: CustomPropTypes.elementType,
       groupBy:        CustomPropTypes.accessor,
 

--- a/src/DropdownList.jsx
+++ b/src/DropdownList.jsx
@@ -33,8 +33,8 @@ var propTypes = {
   valueComponent: CustomPropTypes.elementType,
   itemComponent:  CustomPropTypes.elementType,
   listComponent:  CustomPropTypes.elementType,
-  beforeListComponent: CustomPropTypes.elementType,
-  afterListComponent: CustomPropTypes.elementType,
+  beforeListComponent: React.PropTypes.any,
+  afterListComponent: React.PropTypes.any,
 
   groupComponent: CustomPropTypes.elementType,
   groupBy:        CustomPropTypes.accessor,


### PR DESCRIPTION
`"Invalid prop `afterListComponent` specified in  `ComboBox`. Expected an Element `type`, not an actual Element"`

```
<Combobox
  afterListComponent={( <AddButton onClick={onClickAdd} label={addLabel} /> )}
/>
```

Fix: Combobox needs to accept `React.PropTypes.any`
