### PR TITLE
Add tetherPopup option to Combobox component

### DIFF
--- a/docs/components/pages/ComboBox.api.md
+++ b/docs/components/pages/ComboBox.api.md
@@ -123,6 +123,9 @@ initialization value for uncontrolled widgets.
 Called fires when the {widgetName} is about to open or close. `onToggle` should be used
 when the `open` prop is set otherwise the widget will never open or close.
 
+### tetherPopup?{ type: 'Boolean' }
+
+Flag the {widgetName} to tether its popup instead of positioning it absolutely. Big thanks to [tetherJS](http://github.hubspot.com/tether/).
 
 ### busy?{ type: 'Boolean', default: "false" }
 

--- a/lib/Combobox.js
+++ b/lib/Combobox.js
@@ -321,13 +321,15 @@ var ComboBox = _react2['default'].createClass(babelHelpers.createDecoratedObject
       _react2['default'].createElement(
         PopupComponent,
         babelHelpers._extends({}, popupProps, {
+          onOpening: function () {
+            return _this.refs.list.forceUpdate();
+          },
           getTetherFocus: function () {
-            return _this.refs.input;
+            return _this.refs.list.refs.ul;
           },
           onBlur: this._focus.bind(null, false),
-          onOpening: this.handlePopupOpening,
           onKeyDown: this._keyDown,
-          onOpen: this.focus,
+          onOpen: this._focus.bind(null, true),
           onRequestClose: this.close,
           popupStyle: popupStyle
         }),
@@ -395,14 +397,6 @@ var ComboBox = _react2['default'].createClass(babelHelpers.createDecoratedObject
   key: 'focus',
   value: function focus() {
     this.refs.input.focus();
-  }
-}, {
-  key: 'handlePopupOpening',
-  value: function handlePopupOpening() {
-    if (this.props.tetherPopup) {
-      _utilCompat2['default'].findDOMNode(this.refs.list).focus();
-    }
-    this.refs.list.forceUpdate();
   }
 }, {
   key: '_focus',

--- a/lib/Combobox.js
+++ b/lib/Combobox.js
@@ -264,9 +264,7 @@ var ComboBox = _react2['default'].createClass(babelHelpers.createDecoratedObject
       babelHelpers._extends({}, elementProps, {
         ref: 'element',
         onKeyDown: tetherPopup ? null : this._keyDown,
-        onFocus: tetherPopup ? function () {
-          return _this.setState({ focused: true });
-        } : this._focus.bind(null, true),
+        onFocus: this._focus.bind(null, true),
         onBlur: tetherPopup ? function () {
           return _this.setState({ focused: false });
         } : this._focus.bind(null, false),
@@ -329,7 +327,7 @@ var ComboBox = _react2['default'].createClass(babelHelpers.createDecoratedObject
           },
           onBlur: this._focus.bind(null, false),
           onKeyDown: this._keyDown,
-          onOpen: this._focus.bind(null, true),
+          onOpen: this.focus,
           onRequestClose: this.close,
           popupStyle: popupStyle
         }),
@@ -359,10 +357,15 @@ var ComboBox = _react2['default'].createClass(babelHelpers.createDecoratedObject
   key: '_onSelect',
   decorators: [_utilInteraction.widgetEditable],
   value: function _onSelect(data) {
+    var _props3 = this.props;
+    var onSelect = _props3.onSelect;
+    var tetherPopup = _props3.tetherPopup;
+
     this.close();
-    _utilWidgetHelpers.notify(this.props.onSelect, data);
+    _utilWidgetHelpers.notify(onSelect, data);
     this.change(data);
     this.focus();
+    if (tetherPopup) this._focus(false);
   }
 }, {
   key: '_inputKeyDown',
@@ -373,9 +376,9 @@ var ComboBox = _react2['default'].createClass(babelHelpers.createDecoratedObject
 }, {
   key: '_inputTyping',
   value: function _inputTyping(e) {
-    var _props3 = this.props;
-    var data = _props3.data;
-    var textField = _props3.textField;
+    var _props4 = this.props;
+    var data = _props4.data;
+    var textField = _props4.textField;
 
     var shouldSuggest = !!this.props.suggest,
         strVal = e.target.value,
@@ -481,10 +484,10 @@ var ComboBox = _react2['default'].createClass(babelHelpers.createDecoratedObject
 }, {
   key: 'suggest',
   value: function suggest(data, value) {
-    var _props4 = this.props;
-    var textField = _props4.textField;
-    var suggest = _props4.suggest;
-    var minLength = _props4.minLength;
+    var _props5 = this.props;
+    var textField = _props5.textField;
+    var suggest = _props5.suggest;
+    var minLength = _props5.minLength;
 
     var word = _utilDataHelpers.dataText(value, textField),
         suggestion;

--- a/lib/Combobox.js
+++ b/lib/Combobox.js
@@ -24,6 +24,10 @@ var _Popup = require('./Popup');
 
 var _Popup2 = babelHelpers.interopRequireDefault(_Popup);
 
+var _TetheredPopup = require('./TetheredPopup');
+
+var _TetheredPopup2 = babelHelpers.interopRequireDefault(_TetheredPopup);
+
 var _WidgetButton = require('./WidgetButton');
 
 var _WidgetButton2 = babelHelpers.interopRequireDefault(_WidgetButton);
@@ -99,6 +103,8 @@ var propTypes = {
 
   busy: _react2['default'].PropTypes.bool,
 
+  tetherPopup: _react2['default'].PropTypes.bool,
+
   dropUp: _react2['default'].PropTypes.bool,
   duration: _react2['default'].PropTypes.number, //popup
 
@@ -153,6 +159,8 @@ var ComboBox = _react2['default'].createClass(babelHelpers.createDecoratedObject
       suggest: false,
       filter: false,
       delay: 500,
+      tetherPopup: false,
+      popupStyle: {},
 
       messages: msgs(),
       ariaActiveDescendantKey: 'combobox'
@@ -210,6 +218,8 @@ var ComboBox = _react2['default'].createClass(babelHelpers.createDecoratedObject
     var valueField = _props2.valueField;
     var textField = _props2.textField;
     var groupBy = _props2.groupBy;
+    var tetherPopup = _props2.tetherPopup;
+    var popupStyle = _props2.popupStyle;
     var messages = _props2.messages;
     var data = _props2.data;
     var busy = _props2.busy;
@@ -227,10 +237,11 @@ var ComboBox = _react2['default'].createClass(babelHelpers.createDecoratedObject
     var List = _props2.listComponent;
 
     List = List || groupBy && _ListGroupable2['default'] || _List2['default'];
+    var PopupComponent = tetherPopup ? _TetheredPopup2['default'] : _Popup2['default'];
 
     var elementProps = omit(this.props, Object.keys(propTypes));
     var listProps = pick(this.props, Object.keys(List.propTypes));
-    var popupProps = pick(this.props, Object.keys(_Popup2['default'].propTypes));
+    var popupProps = pick(this.props, Object.keys(PopupComponent.propTypes));
 
     var _state = this.state;
     var focusedItem = _state.focusedItem;
@@ -252,9 +263,13 @@ var ComboBox = _react2['default'].createClass(babelHelpers.createDecoratedObject
       'div',
       babelHelpers._extends({}, elementProps, {
         ref: 'element',
-        onKeyDown: this._keyDown,
-        onFocus: this._focus.bind(null, true),
-        onBlur: this._focus.bind(null, false),
+        onKeyDown: tetherPopup ? null : this._keyDown,
+        onFocus: tetherPopup ? function () {
+          return _this.setState({ focused: true });
+        } : this._focus.bind(null, true),
+        onBlur: tetherPopup ? function () {
+          return _this.setState({ focused: false });
+        } : this._focus.bind(null, false),
         tabIndex: '-1',
         className: _classnames2['default'](className, 'rw-combobox', 'rw-widget', (_cx = {
           'rw-state-focus': focused,
@@ -288,6 +303,7 @@ var ComboBox = _react2['default'].createClass(babelHelpers.createDecoratedObject
         autoFocus: autoFocus,
         tabIndex: tabIndex,
         suggest: suggest,
+        onClick: tetherPopup ? this.open : function () {},
         name: name,
         role: 'combobox',
         'aria-owns': listID,
@@ -304,12 +320,17 @@ var ComboBox = _react2['default'].createClass(babelHelpers.createDecoratedObject
         onKeyDown: this._inputKeyDown
       }),
       _react2['default'].createElement(
-        _Popup2['default'],
+        PopupComponent,
         babelHelpers._extends({}, popupProps, {
-          onOpening: function () {
-            return _this.refs.list.forceUpdate();
+          getTetherFocus: function () {
+            return _this.refs.input;
           },
-          onRequestClose: this.close
+          onBlur: this._focus.bind(null, false),
+          onOpening: this.handlePopupOpening,
+          onKeyDown: this._keyDown,
+          onOpen: this.focus,
+          onRequestClose: this.close,
+          popupStyle: popupStyle
         }),
         _react2['default'].createElement(
           'div',
@@ -375,6 +396,14 @@ var ComboBox = _react2['default'].createClass(babelHelpers.createDecoratedObject
   key: 'focus',
   value: function focus() {
     this.refs.input.focus();
+  }
+}, {
+  key: 'handlePopupOpening',
+  value: function handlePopupOpening() {
+    if (this.props.tetherPopup) {
+      _utilCompat2['default'].findDOMNode(this.refs.list).focus();
+    }
+    this.refs.list.forceUpdate();
   }
 }, {
   key: '_focus',

--- a/lib/Combobox.js
+++ b/lib/Combobox.js
@@ -263,7 +263,7 @@ var ComboBox = _react2['default'].createClass(babelHelpers.createDecoratedObject
       'div',
       babelHelpers._extends({}, elementProps, {
         ref: 'element',
-        onKeyDown: tetherPopup ? null : this._keyDown,
+        onKeyDown: this._keyDown,
         onFocus: this._focus.bind(null, true),
         onBlur: tetherPopup ? function () {
           return _this.setState({ focused: false });
@@ -326,7 +326,6 @@ var ComboBox = _react2['default'].createClass(babelHelpers.createDecoratedObject
             return _this.refs.list.refs.ul;
           },
           onBlur: this._focus.bind(null, false),
-          onKeyDown: this._keyDown,
           onOpen: this.focus,
           onRequestClose: this.close,
           popupStyle: popupStyle

--- a/lib/Combobox.js
+++ b/lib/Combobox.js
@@ -303,7 +303,6 @@ var ComboBox = _react2['default'].createClass(babelHelpers.createDecoratedObject
         autoFocus: autoFocus,
         tabIndex: tabIndex,
         suggest: suggest,
-        onClick: tetherPopup ? this.open : function () {},
         name: name,
         role: 'combobox',
         'aria-owns': listID,

--- a/src/Combobox.jsx
+++ b/src/Combobox.jsx
@@ -179,7 +179,7 @@ var ComboBox = React.createClass({
         {...elementProps}
         ref="element"
         onKeyDown={tetherPopup ? null : this._keyDown}
-        onFocus={tetherPopup ? () => this.setState({focused: true}) : this._focus.bind(null, true)}
+        onFocus={this._focus.bind(null, true)}
         onBlur ={tetherPopup ? () => this.setState({focused: false}) : this._focus.bind(null, false)}
         tabIndex={'-1'}
         className={cx(className, 'rw-combobox', 'rw-widget', {
@@ -230,7 +230,7 @@ var ComboBox = React.createClass({
           getTetherFocus={() => this.refs.list.refs.ul}
           onBlur={this._focus.bind(null, false)}
           onKeyDown={this._keyDown}
-          onOpen={this._focus.bind(null, true)}
+          onOpen={this.focus}
           onRequestClose={this.close}
           popupStyle={popupStyle}
         >
@@ -267,10 +267,12 @@ var ComboBox = React.createClass({
 
   @widgetEditable
   _onSelect(data){
+    const { onSelect, tetherPopup } = this.props;
     this.close()
-    notify(this.props.onSelect, data)
+    notify(onSelect, data)
     this.change(data)
     this.focus();
+    if (tetherPopup) this._focus(false);
   },
 
   _inputKeyDown(e){

--- a/src/Combobox.jsx
+++ b/src/Combobox.jsx
@@ -226,11 +226,11 @@ var ComboBox = React.createClass({
         />
         <PopupComponent
           {...popupProps}
-          getTetherFocus={() => this.refs.input}
+          onOpening={() => this.refs.list.forceUpdate()}
+          getTetherFocus={() => this.refs.list.refs.ul}
           onBlur={this._focus.bind(null, false)}
-          onOpening={this.handlePopupOpening}
           onKeyDown={this._keyDown}
-          onOpen={this.focus}
+          onOpen={this._focus.bind(null, true)}
           onRequestClose={this.close}
           popupStyle={popupStyle}
         >
@@ -302,13 +302,6 @@ var ComboBox = React.createClass({
 
   focus() {
     this.refs.input.focus()
-  },
-
-  handlePopupOpening() {
-    if (this.props.tetherPopup) {
-      compat.findDOMNode(this.refs.list).focus();
-    }
-    this.refs.list.forceUpdate()
   },
 
   @widgetEnabled

--- a/src/Combobox.jsx
+++ b/src/Combobox.jsx
@@ -178,7 +178,7 @@ var ComboBox = React.createClass({
       <div
         {...elementProps}
         ref="element"
-        onKeyDown={tetherPopup ? null : this._keyDown}
+        onKeyDown={this._keyDown}
         onFocus={this._focus.bind(null, true)}
         onBlur ={tetherPopup ? () => this.setState({focused: false}) : this._focus.bind(null, false)}
         tabIndex={'-1'}
@@ -229,7 +229,6 @@ var ComboBox = React.createClass({
           onOpening={() => this.refs.list.forceUpdate()}
           getTetherFocus={() => this.refs.list.refs.ul}
           onBlur={this._focus.bind(null, false)}
-          onKeyDown={this._keyDown}
           onOpen={this.focus}
           onRequestClose={this.close}
           popupStyle={popupStyle}

--- a/src/Combobox.jsx
+++ b/src/Combobox.jsx
@@ -209,7 +209,7 @@ var ComboBox = React.createClass({
           autoFocus={autoFocus}
           tabIndex={tabIndex}
           suggest={suggest}
-          onClick={tetherPopup && this.toggle}
+          onClick={tetherPopup ? this.open : () => {}}
           name={name}
           role='combobox'
           aria-owns={listID}
@@ -228,9 +228,9 @@ var ComboBox = React.createClass({
         <PopupComponent
           {...popupProps}
           onBlur={this._focus.bind(null, false)}
-          onKeyDown={this.focus}
-          getTetherFocus={() => this.refs.list.refs.ul}
+          getTetherFocus={() => this.refs.input}
           onOpening={() => this.refs.list.forceUpdate()}
+          onOpen={tetherPopup ? () => this.refs.input.focus() : popupProps.onOpen}
           onRequestClose={this.close}
           popupStyle={popupStyle}
         >

--- a/src/Combobox.jsx
+++ b/src/Combobox.jsx
@@ -209,7 +209,6 @@ var ComboBox = React.createClass({
           autoFocus={autoFocus}
           tabIndex={tabIndex}
           suggest={suggest}
-          onClick={tetherPopup ? this.open : () => {}}
           name={name}
           role='combobox'
           aria-owns={listID}

--- a/src/Combobox.jsx
+++ b/src/Combobox.jsx
@@ -227,10 +227,11 @@ var ComboBox = React.createClass({
         />
         <PopupComponent
           {...popupProps}
-          onBlur={this._focus.bind(null, false)}
           getTetherFocus={() => this.refs.input}
-          onOpening={() => this.refs.list.forceUpdate()}
-          onOpen={tetherPopup ? () => this.refs.input.focus() : popupProps.onOpen}
+          onBlur={this._focus.bind(null, false)}
+          onOpening={this.handlePopupOpening}
+          onKeyDown={this._keyDown}
+          onOpen={this.focus}
           onRequestClose={this.close}
           popupStyle={popupStyle}
         >
@@ -302,6 +303,13 @@ var ComboBox = React.createClass({
 
   focus() {
     this.refs.input.focus()
+  },
+
+  handlePopupOpening() {
+    if (this.props.tetherPopup) {
+      compat.findDOMNode(this.refs.list).focus();
+    }
+    this.refs.list.forceUpdate()
   },
 
   @widgetEnabled

--- a/src/TetheredPopup.jsx
+++ b/src/TetheredPopup.jsx
@@ -216,7 +216,6 @@ module.exports = React.createClass({
           anim.className = anim.className.replace(/ ?rw-popup-animating/g, '')
           anim.style.overflofw = 'visible';
 
-          contentEl.focus();
           if (onOpen) onOpen();
       })
   },

--- a/src/TetheredPopup.jsx
+++ b/src/TetheredPopup.jsx
@@ -188,6 +188,7 @@ module.exports = React.createClass({
 
     const { onOpen, onKeyDown, getTetherFocus } = this.props;
 
+    contentEl.focus()
     let focusComponent = compat.findDOMNode(getTetherFocus());
 
     if(focusComponent) {
@@ -216,6 +217,7 @@ module.exports = React.createClass({
           anim.className = anim.className.replace(/ ?rw-popup-animating/g, '')
           anim.style.overflofw = 'visible';
 
+          contentEl.focus();
           if (onOpen) onOpen();
       })
   },

--- a/src/TetheredPopup.jsx
+++ b/src/TetheredPopup.jsx
@@ -188,7 +188,6 @@ module.exports = React.createClass({
 
     const { onOpen, onKeyDown, getTetherFocus } = this.props;
 
-    contentEl.focus()
     let focusComponent = compat.findDOMNode(getTetherFocus());
 
     if(focusComponent) {


### PR DESCRIPTION
### Changes
This adds the `tetherPopup` functionality, which `DropdownList` has, to the `Combobox` component. The `tetherPopup` flag causes `Combobox` to use the [tetherJS](http://github.hubspot.com/tether/) library to move the combobox popup to the end of the document body.

### Why
Invoicing team would like the Combobox to have this functionality because we have a Combobox in a table and we want its popup to ignore the css overflow setting of its parent.
