### PR TITLE
Render nothing in TagList if there is no data.

### DIFF
--- a/lib/MultiselectTagList.js
+++ b/lib/MultiselectTagList.js
@@ -74,6 +74,10 @@ exports['default'] = _react2['default'].createClass({
 
     var id = _utilWidgetHelpers.instanceId(this);
 
+    if (value.length === 0) {
+      return null;
+    }
+
     return _react2['default'].createElement(
       'ul',
       babelHelpers._extends({}, props, {

--- a/src/MultiselectTagList.jsx
+++ b/src/MultiselectTagList.jsx
@@ -53,6 +53,10 @@ export default React.createClass({
 
       var id = instanceId(this);
 
+      if (value.length === 0) {
+          return null;
+       }
+
       return (
         <ul {...props}
           role='listbox'


### PR DESCRIPTION
Rendering a `<ul>` without any `<li>` (no data) would cause invariant issues in inspections. Changed it so it wont render anything if there is not data. 